### PR TITLE
Remove "$" Before Code Blocks to Prevent Errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,29 +12,40 @@ This Docker Compose project makes it easy to start and run an Ozone FOSS server 
 ### Run Ozone FOSS locally
 Install Git, Maven and Docker Compose and type in the following in a terminal:
 <table>
-<tr>
-<td> macOS </td> <td> Linux </td>
-</tr>
-<tr>
-<td>
-
-```bash
-$ git clone https://github.com/ozone-his/ozone-docker
-$ cd ozone-docker
-$ ./start-demo.sh
-```
-
-</td>
-<td>
-
-```bash
-$ git clone https://github.com/ozone-his/ozone-docker
-$ cd ozone-docker
-$ sudo -E ./start-demo.sh
-```
-
-</td>
-</tr>
+  <tr>
+    <th>macOS</th>
+    <th>Linux</th>
+  </tr>
+  <tr>
+    <td>
+      Step 1
+      <pre><code>git clone https://github.com/ozone-his/ozone-docker</code></pre>
+    </td>
+    <td>
+      Step 1
+      <pre><code>git clone https://github.com/ozone-his/ozone-docker</code></pre>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      Step 2
+      <pre><code>cd ozone-docker</code></pre>
+    </td>
+    <td>
+      Step 2
+      <pre><code>cd ozone-docker</code></pre>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      Step 3
+      <pre><code>./start-demo.sh</code></pre>
+    </td>
+    <td>
+      Step 3
+      <pre><code>sudo -E ./start-demo.sh</code></pre>
+    </td>
+  </tr>
 </table>
 
 It may take some time to download and setup Ozone for the first time, so hang tight :hourglass_flowing_sand:

--- a/readme/manual-setup.md
+++ b/readme/manual-setup.md
@@ -7,28 +7,28 @@ Welcome to the Ozone FOSS manual setup guide. This guide details the setup of Oz
 Move to the location of your choice, e.g., your home folder:
 
 ```bash
-$ cd ~/
+cd ~/
 ```
 
 Then create the Ozone working directory and save the path:
 ```bash
-$ export OZONE_DIR=$PWD/ozone && \
+export OZONE_DIR=$PWD/ozone && \
 mkdir -p $OZONE_DIR && cd $OZONE_DIR
 ```
 ### Clone the ozone-docker project
 
 ```bash
-$ git clone https://github.com/ozone-his/ozone-docker
+git clone https://github.com/ozone-his/ozone-docker
 ```
 
 ```bash
-$ cd ozone-docker
+cd ozone-docker
 ```
 
 ### Download and extract the distro
 
 ```bash
-$ export VERSION=1.0.0-SNAPSHOT && \
+export VERSION=1.0.0-SNAPSHOT && \
 ./mvnw org.apache.maven.plugins:maven-dependency-plugin:3.2.0:get -DremoteRepositories=https://nexus.mekomsolutions.net/repository/maven-public -Dartifact=com.ozonehis:ozone-distro:$VERSION:zip -Dtransitive=false --legacy-local-repository && \
 ./mvnw org.apache.maven.plugins:maven-dependency-plugin:3.2.0:unpack -Dproject.basedir=$OZONE_DIR -Dartifact=com.ozonehis:ozone-distro:$VERSION:zip -DoutputDirectory=$OZONE_DIR/ozone-distro-$VERSION
 ```
@@ -60,7 +60,7 @@ export ODOO_CONFIG_FILE_PATH=$DISTRO_PATH/odoo_config/config/odoo.conf
 
 If you are developing on Ozone and are building the Ozone distro in your local environment, then you would need to override `DISTRO_PATH` to point to your distro build folder. For example if your working folder is `/your/path/to/ozone-distro` for the distro then you would want to do something like this:
 ```bash
-$ export DISTRO_PATH=/your/path/to/ozone-distro/target/ozone-distro-1.0.0-SNAPSHOT
+export DISTRO_PATH=/your/path/to/ozone-distro/target/ozone-distro-1.0.0-SNAPSHOT
 ```
 
 ### Start Ozone
@@ -72,14 +72,14 @@ $ export DISTRO_PATH=/your/path/to/ozone-distro/target/ozone-distro-1.0.0-SNAPSH
 <td>
 
 ```bash
-$ docker compose -p $DISTRO_GROUP up
+docker compose -p $DISTRO_GROUP up
 ```
 
 </td>
 <td>
 
 ```bash
-$ sudo -E docker compose -p $DISTRO_GROUP up
+sudo -E docker compose -p $DISTRO_GROUP up
 ```
 
 </td>


### PR DESCRIPTION
I have removed the $ in README code blocks to prevent errors when installing. Before, users would click the copy button on the code block, and when pasted, it would show an error, saying "$" is not a command.