### PR TITLE
OZ-126: Added O3_BACKEND_TAG envvar.

### DIFF
--- a/.env
+++ b/.env
@@ -27,10 +27,8 @@ OPENMRS_DB_HOST=mysql
 OPENMRS_DB_PORT=3306
 OPENMRS_DB_NAME=openmrs
 
-# OpenMRS backend docker image tag
+# OpenMRS frontend and backend Docker image tags
 O3_BACKEND_TAG
-
-# OpenMRS frontend docker image tag
 O3_FRONTEND_TAG
 
 #

--- a/.env
+++ b/.env
@@ -27,6 +27,12 @@ OPENMRS_DB_HOST=mysql
 OPENMRS_DB_PORT=3306
 OPENMRS_DB_NAME=openmrs
 
+# OpenMRS backend docker image tag
+O3_BACKEND_TAG
+
+# OpenMRS frontend docker image tag
+O3_FRONTEND_TAG
+
 #
 # MySQL
 #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
 
   # OpenMRS
   openmrs:
-    image: openmrs/openmrs-reference-application-3-backend:${TAG:-nightly}
+    image: openmrs/openmrs-reference-application-3-backend:${O3_BACKEND_TAG:-nightly}
     depends_on:
       mysql:
         condition: service_started


### PR DESCRIPTION
PR is ensuring proper naming of the Backend docker image tag and adding it together with the Frontend one to the `.env` file as a way of implicitly documenting them.
Ticket: https://mekomsolutions.atlassian.net/browse/OZ-126