### PR TITLE
MEDME-5: Tweak Ozone Docker to allow SPA_CONFIG_URLS override

### DIFF
--- a/.env
+++ b/.env
@@ -27,6 +27,11 @@ OPENMRS_DB_HOST=mysql
 OPENMRS_DB_PORT=3306
 OPENMRS_DB_NAME=openmrs
 
+#
+# OpenMRS frontend
+#
+SPA_CONFIG_URLS=/openmrs/spa/ozone/ozone-frontend-config.json
+
 # OpenMRS frontend and backend Docker image tags
 O3_BACKEND_TAG
 O3_FRONTEND_TAG

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -204,7 +204,7 @@ services:
     environment:
       SPA_PATH: /openmrs/spa
       API_URL: /openmrs
-      SPA_CONFIG_URLS: /openmrs/spa/ozone/ozone-frontend-config.json
+      SPA_CONFIG_URLS: ${SPA_CONFIG_URLS}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost/"]
       timeout: 5s


### PR DESCRIPTION
https://mekomsolutions.atlassian.net/browse/MEDME-5

In order to provide custom O3 frontend config files, the SPA_CONFIG_URLS can be provided to point to as many files as needed.
