### PR TITLE
Fix proxy-rules for the OpenMRS frontend

### DIFF
--- a/proxy/resources/proxy-rules
+++ b/proxy/resources/proxy-rules
@@ -8,8 +8,8 @@
   RewriteRule (.*) /openmrs/spa/ [R=303,L]
 
   # Frontend
-<Location  /openmrs/spa>
-  ProxyPass http://frontend
+<Location  /openmrs/spa/>
+  ProxyPass http://frontend/
   ProxyPassReverse /
   ProxyPreserveHost Off
 </Location>  


### PR DESCRIPTION
Basically, the frontend container is setup to run as if it were always mounted at /, so to proxy it from a sub-URL, like /openmrs/spa/ we need to tell the web server to treat that as the context.

Without this change, the initial request goes to /openmrs/spahome, which doesn't get properly served (because this doesn't resolve to a URL). With this change, requests properly go to /openmrs/spa/home