### PR TITLE
OZ-953: Remove `ozone_settings` from Odoo addons list

### DIFF
--- a/docker-compose-odoo.yml
+++ b/docker-compose-odoo.yml
@@ -9,7 +9,7 @@ services:
       - HOST=${POSTGRES_DB_HOST}
       - USER=${ODOO_DB_USER}
       - PASSWORD=${ODOO_DB_PASSWORD}
-      - ADDONS=sale_management,stock,account_account,purchase,mrp,odoo_initializer,ozone_settings,mrp_product_expiry,product_expiry,l10n_generic_coa
+      - ADDONS=sale_management,stock,account_account,purchase,mrp,odoo_initializer,mrp_product_expiry,product_expiry,l10n_generic_coa
       - INITIALIZER_DATA_FILES_PATH=/mnt/odoo_config
       - INITIALIZER_CONFIG_FILE_PATH=/mnt/odoo_config/initializer_config.json
     image: mekomsolutions/odoo


### PR DESCRIPTION
Issue: https://mekomsolutions.atlassian.net/browse/OZ-953

This PR removes `ozone_settings` from Odoo addons configured list.