### PR TITLE
Set Keycloak's proxy mode to `passthrough` as SSL termination is handled at proxy

### DIFF
--- a/docker-compose-keycloak.yml
+++ b/docker-compose-keycloak.yml
@@ -11,7 +11,7 @@ services:
       PROXY_ADDRESS_FORWARDING: "true"
       KC_HTTP_ENABLED: 'true'
       KC_HOSTNAME_STRICT_BACKCHANNEL: "true"
-      KC_PROXY: reencrypt
+      KC_PROXY: passthrough
       KC_HEALTH_ENABLED: 'true'
       KC_METRICS_ENABLED: 'true'
       KEYCLOAK_DATABASE_VENDOR: postgresql


### PR DESCRIPTION
- `reencrypt`: Keycloak expects SSL between the proxy and itself.
- `passthrough`: Keycloak trusts the proxy for SSL termination and treats incoming requests as secure if the proxy sets the appropriate headers (like `X-Forwarded-Proto: https`).

This ensures Keycloak generates correct URLs and handles security as expected when SSL is terminated at the proxy.