### PR TITLE
OZ-838: Use `openmrs-core:2.7.4-amazoncorretto-17` for bundled docker

### DIFF
--- a/bundled-docker/openmrs/Dockerfile
+++ b/bundled-docker/openmrs/Dockerfile
@@ -1,4 +1,4 @@
-FROM openmrs/openmrs-core:2.6.x-nightly-amazoncorretto-11
+FROM openmrs/openmrs-core:2.7.4-amazoncorretto-17
 
 # Add modules & configurations for the ozone distribution
 ADD distro/binaries/openmrs/modules /openmrs/distribution/openmrs_modules


### PR DESCRIPTION
Issue: https://mekomsolutions.atlassian.net/browse/OZ-838

This PR sets the right version of OpenMRS core base docker image for bundled docker.