### PR TITLE
MG-61: Update OE Docker images to use 'develop' tag for all services

### DIFF
--- a/docker-compose-openelis.yml
+++ b/docker-compose-openelis.yml
@@ -14,7 +14,7 @@ services:
       - "${OPENELIS_CERTS:-certs-vol}:/etc/ssl/certs/"
 
   oe.openelis.org:
-    image: itechuw/openelis-global-2:3.2.1.3
+    image: itechuw/openelis-global-2:develop
     platform: linux/amd64
     depends_on:
       - postgresql
@@ -44,7 +44,7 @@ services:
       - source: common.properties
 
   fhir.openelis.org:
-    image: itechuw/openelis-global-2-fhir:3.2.1.3
+    image: itechuw/openelis-global-2-fhir:develop
     platform: linux/amd64
     depends_on:
       - postgresql
@@ -101,7 +101,7 @@ services:
       - "traefik.http.services.${OPENELIS_TRAEFIK_LABEL}.loadbalancer.server.port=80"
 
   frontend.openelis.org:
-    image: itechuw/openelis-global-2-frontend:3.2.1.3
+    image: itechuw/openelis-global-2-frontend:develop
     platform: linux/amd64
     networks:
       ozone:


### PR DESCRIPTION
This PR updates OpenELIS Docker images to use 'develop' tag for all services