### PR TITLE
Revert "MG-61: Update OE Docker images to use 'develop' tag for all services (#236)"

### DIFF
--- a/docker-compose-openelis.yml
+++ b/docker-compose-openelis.yml
@@ -14,7 +14,7 @@ services:
       - "${OPENELIS_CERTS:-certs-vol}:/etc/ssl/certs/"
 
   oe.openelis.org:
-    image: itechuw/openelis-global-2:develop
+    image: itechuw/openelis-global-2:3.2.1.3
     platform: linux/amd64
     depends_on:
       - postgresql
@@ -46,7 +46,7 @@ services:
       - source: common.properties
 
   fhir.openelis.org:
-    image: itechuw/openelis-global-2-fhir:develop
+    image: itechuw/openelis-global-2-fhir:3.2.1.3
     platform: linux/amd64
     depends_on:
       - postgresql
@@ -103,7 +103,7 @@ services:
       - "traefik.http.services.${OPENELIS_TRAEFIK_LABEL}.loadbalancer.server.port=80"
 
   frontend.openelis.org:
-    image: itechuw/openelis-global-2-frontend:develop
+    image: itechuw/openelis-global-2-frontend:3.2.1.3
     platform: linux/amd64
     networks:
       ozone:


### PR DESCRIPTION
This PR reverts commit b80b0b02d181f78d448b5b9930fe774a45b1ce06.