### PR TITLE
MG-61: Upgrade OE Docker images to use '3.2.1.4'

### DIFF
--- a/docker-compose-openelis.yml
+++ b/docker-compose-openelis.yml
@@ -14,7 +14,7 @@ services:
       - "${OPENELIS_CERTS:-certs-vol}:/etc/ssl/certs/"
 
   oe.openelis.org:
-    image: itechuw/openelis-global-2:3.2.1.3
+    image: itechuw/openelis-global-2:3.2.1.4
     platform: linux/amd64
     depends_on:
       - postgresql
@@ -37,7 +37,7 @@ services:
     volumes:
       - "${OPENELIS_TRUST_STORE:-key_trust-store-volume}:/etc/openelis-global"
       - "${OPENELIS_CONFIG_PATH}/plugins/:/var/lib/openelis-global/plugins"
-      - "${OPENELIS_CONFIG_PATH}/properties/SystemConfiguration.properties:/var/lib/openelis-global/properties/SystemConfiguration.properties"
+      - "${OPENELIS_CONFIG_PATH}/properties:/var/lib/openelis-global/properties"
       - "${OPENELIS_CONFIG_PATH}/analyzer/analyzer-test-map.csv:/var/lib/openelis-global/analyzer/analyzer-test-map.csv"
       - "${OPENELIS_CONFIG_PATH}/odoo/odoo-test-product-mapping.csv:/var/lib/openelis-global/odoo/odoo-test-product-mapping.csv"
       - "${OPENELIS_CONFIG_PATH}/ocl:/var/lib/openelis-global/ocl"
@@ -46,7 +46,7 @@ services:
       - source: common.properties
 
   fhir.openelis.org:
-    image: itechuw/openelis-global-2-fhir:3.2.1.3
+    image: itechuw/openelis-global-2-fhir:3.2.1.4
     platform: linux/amd64
     depends_on:
       - postgresql
@@ -103,7 +103,7 @@ services:
       - "traefik.http.services.${OPENELIS_TRAEFIK_LABEL}.loadbalancer.server.port=80"
 
   frontend.openelis.org:
-    image: itechuw/openelis-global-2-frontend:3.2.1.3
+    image: itechuw/openelis-global-2-frontend:3.2.1.4
     platform: linux/amd64
     networks:
       ozone:


### PR DESCRIPTION
This PR updates OE Docker images to use `3.2.1.4`