### PR TITLE
Upgrade OE Docker images to use '3.2.1.6'

### DIFF
--- a/docker-compose-openelis.yml
+++ b/docker-compose-openelis.yml
@@ -14,7 +14,7 @@ services:
       - "${OPENELIS_CERTS:-certs-vol}:/etc/ssl/certs/"
 
   oe.openelis.org:
-    image: itechuw/openelis-global-2:3.2.1.4
+    image: itechuw/openelis-global-2:3.2.1.6
     platform: linux/amd64
     depends_on:
       - postgresql
@@ -46,7 +46,7 @@ services:
       - source: common.properties
 
   fhir.openelis.org:
-    image: itechuw/openelis-global-2-fhir:3.2.1.4
+    image: itechuw/openelis-global-2-fhir:3.2.1.6
     platform: linux/amd64
     depends_on:
       - postgresql
@@ -103,7 +103,7 @@ services:
       - "traefik.http.services.${OPENELIS_TRAEFIK_LABEL}.loadbalancer.server.port=80"
 
   frontend.openelis.org:
-    image: itechuw/openelis-global-2-frontend:3.2.1.4
+    image: itechuw/openelis-global-2-frontend:3.2.1.6
     platform: linux/amd64
     networks:
       ozone:


### PR DESCRIPTION
This PR upgrades OE Docker images to use `3.2.1.6`.