### PR TITLE
Remove `l10n_generic_coa` and `account_account` from ADDONS and replace with just account

### DIFF
--- a/.env
+++ b/.env
@@ -135,7 +135,7 @@ ODOO_INITIALIZER_DATA_FILES_PATH=
 ODOO_CONFIG_PATH=
 ODOO_INITIALIZER_CONFIG_FILE_PATH=
 ODOO_DATABASE=odoo
-ODOO_ADDONS=sale_management,stock,account_account,purchase,mrp,odoo_initializer,mrp_product_expiry,product_expiry,l10n_generic_coa
+ODOO_ADDONS=sale_management,stock,account,purchase,mrp,odoo_initializer,mrp_product_expiry,product_expiry
 
 #
 # ERPNext


### PR DESCRIPTION
The correct modules for accounting in Odoo 16+ are:
- `account` (replaces `account_account`)
- `l10n_generic_coa` was removed; charts of accounts are now country-specific or handled by `account`