### PR TITLE
MG-8: Update Keycloak Docker compose to use a generic themes path

### DIFF
--- a/docker-compose-keycloak.yml
+++ b/docker-compose-keycloak.yml
@@ -9,7 +9,7 @@ services:
        /opt/keycloak/bin/kc.sh start --optimized --import-realm"
     volumes:
       - ${KEYCLOAK_CONFIG_PATH}/realms:/opt/keycloak/data/import
-      - ${KEYCLOAK_CONFIG_PATH}/themes/carbon:/opt/keycloak/themes/carbon
+      - ${KEYCLOAK_CONFIG_PATH}/themes:/opt/keycloak/themes
     environment:
       KC_HOSTNAME: ${SERVER_SCHEME}://${KEYCLOAK_HOSTNAME}
       KC_HOSTNAME_ADMIN: ${SERVER_SCHEME}://${KEYCLOAK_HOSTNAME}


### PR DESCRIPTION
This PR updates Keycloak Docker compose to use a generic themes path